### PR TITLE
Fix parsing DSN so query string is handled correctly

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,49 @@ conventional well known text-based MySQL protocol.
 If you are looking for a driver using the MySQL port 3306, please use the
 excellent [github.com/go-sql-driver/mysql][3].
 
+Installation
+------------
+
+The `pxmysql` package supports Go 1.19 and greater.
+
+```go get -u github.com/golistic/pxmysql```
+
+Quick Start
+-----------
+
+The below code connects to the MySQL server and gets the current time.
+
+Note! This is MySQL Protocol X; it uses TCP port `33060` (not `3306`!).
+
+```go
+package main
+
+import (
+  "database/sql"
+  "fmt"
+  "log"
+
+  _ "github.com/golistic/pxmysql"
+)
+
+func main() {
+  db, err := sql.Open("mysqlpx", "scott:tiger@tcp(127.0.0.1:33060)/somedb?useTLS=true")
+  if err != nil {
+    log.Fatalln(err)
+  }
+
+  var n string
+  if err := db.QueryRow("SELECT NOW()").Scan(&n); err != nil {
+    log.Fatalln(err)
+  }
+
+  fmt.Printf("Server time: %s", n)
+}
+```
+
+The `useTLS` option is required when you use a user set to use the authentication
+method `caching_sha2_password`.
+
 Features
 --------
 

--- a/datasource.go
+++ b/datasource.go
@@ -9,9 +9,10 @@ import (
 	"strings"
 
 	"github.com/golistic/xconv"
+	"github.com/golistic/xstrings"
 )
 
-var reDSN = regexp.MustCompile(`(.*?):(.*?)@(\w+)\((.*?)\)(?:/(\w+))?(?:/?\?(.*))?`)
+var reDSN = regexp.MustCompile(`(.*?)(?::(.*?))?@(\w+)\((.*?)\)(?:/(\w+))?(\?)?(?:/?(.*))?`)
 
 type DataSource struct {
 	Driver   string
@@ -45,8 +46,8 @@ func ParseDNS(name string) (*DataSource, error) {
 		Schema:   m[0][5],
 	}
 
-	if len(m[0]) == 8 {
-		query, err := url.ParseQuery(m[0][7])
+	if xstrings.SliceHas(m[0], "?") {
+		query, err := url.ParseQuery(m[0][len(m[0])-1])
 		if err != nil {
 			return nil, fmt.Errorf(errMsg, fmt.Errorf("could not parse query part"))
 		}

--- a/datasource_test.go
+++ b/datasource_test.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package pxmysql
+
+import (
+	"testing"
+
+	"github.com/geertjanvdk/xkit/xt"
+)
+
+func TestParseDNS(t *testing.T) {
+	t.Run("parse query string", func(t *testing.T) {
+		dsn := "scott:tiger@tcp(127.0.0.1:33060)/test?useTLS=true"
+		exp := &DataSource{
+			User:     "scott",
+			Password: "tiger",
+			Protocol: "tcp",
+			Address:  "127.0.0.1:33060",
+			Schema:   "test",
+			UseTLS:   true,
+		}
+
+		have, err := ParseDNS(dsn)
+		xt.OK(t, err)
+		xt.Eq(t, exp, have)
+	})
+
+	t.Run("no query string provided", func(t *testing.T) {
+		dsn := "scott:tiger@tcp(127.0.0.1:33060)/test"
+		exp := &DataSource{
+			User:     "scott",
+			Password: "tiger",
+			Protocol: "tcp",
+			Address:  "127.0.0.1:33060",
+			Schema:   "test",
+			UseTLS:   false,
+		}
+
+		have, err := ParseDNS(dsn)
+		xt.OK(t, err)
+		xt.Eq(t, exp, have)
+	})
+
+	t.Run("no default schema with query string", func(t *testing.T) {
+		dsn := "scott:tiger@tcp(127.0.0.1:33060)?useTLS=true"
+		exp := &DataSource{
+			User:     "scott",
+			Password: "tiger",
+			Protocol: "tcp",
+			Address:  "127.0.0.1:33060",
+			Schema:   "",
+			UseTLS:   true,
+		}
+
+		have, err := ParseDNS(dsn)
+		xt.OK(t, err)
+		xt.Eq(t, exp, have)
+	})
+
+	t.Run("no default schema without query string", func(t *testing.T) {
+		dsn := "scott:tiger@tcp(127.0.0.1:33060)"
+		exp := &DataSource{
+			User:     "scott",
+			Password: "tiger",
+			Protocol: "tcp",
+			Address:  "127.0.0.1:33060",
+			Schema:   "",
+			UseTLS:   false,
+		}
+
+		have, err := ParseDNS(dsn)
+		xt.OK(t, err)
+		xt.Eq(t, exp, have)
+	})
+
+	t.Run("no password", func(t *testing.T) {
+		dsn := "scott@tcp(127.0.0.1:33060)/test"
+		exp := &DataSource{
+			User:     "scott",
+			Password: "",
+			Protocol: "tcp",
+			Address:  "127.0.0.1:33060",
+			Schema:   "test",
+			UseTLS:   false,
+		}
+
+		have, err := ParseDNS(dsn)
+		xt.OK(t, err)
+		xt.Eq(t, exp, have)
+	})
+
+	t.Run("unix protocol", func(t *testing.T) {
+		dsn := "scott:tiger@unix(/path/to/socket)/test"
+		exp := &DataSource{
+			User:     "scott",
+			Password: "tiger",
+			Protocol: "unix",
+			Address:  "/path/to/socket",
+			Schema:   "test",
+			UseTLS:   false,
+		}
+
+		have, err := ParseDNS(dsn)
+		xt.OK(t, err)
+		xt.Eq(t, exp, have)
+	})
+}


### PR DESCRIPTION
Previously the query string when parsing the data source was ignored.
This prevented optional settings to be provided such as `useTLS`, which
then did not allow users to sign in to (first time) MySQL when using
`caching_sha2_password`.

We now correctly detect whether there is a query string. This makes now
sure that for example `useTLS` is respected.

We also added missing tests.