### PR TITLE
Fix using connection address without TCP port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 ?dev_*
 *.proto
+cmd/scratch
+_testdata/*.pem

--- a/.idea/copyright/Geert_JM.xml
+++ b/.idea/copyright/Geert_JM.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="Copyright (c) &amp;#36;today.year, Geert JM Vanderkelen" />
+    <option name="myName" value="Geert JM" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,11 @@
+<component name="CopyrightManager">
+  <settings default="Geert JM">
+    <module2copyright>
+      <element module="Project Files" copyright="Geert JM" />
+    </module2copyright>
+    <LanguageOptions name="Go">
+      <option name="fileTypeOverride" value="3" />
+      <option name="block" value="false" />
+    </LanguageOptions>
+  </settings>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,8 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="SqlResolveInspection" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="suppressForPossibleStringLiterals" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/pxmysql.iml
+++ b/.idea/pxmysql.iml
@@ -3,7 +3,6 @@
   <component name="Go" enabled="true" />
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
-      <excludeFolder url="file://$MODULE_DIR$/cmd/scratch" />
       <excludeFolder url="file://$MODULE_DIR$/_support/pxmysql-compose/shared/goapps" />
       <excludeFolder url="file://$MODULE_DIR$/_support/pxmysql-compose/data_bk" />
     </content>

--- a/xmysql/session.go
+++ b/xmysql/session.go
@@ -306,8 +306,8 @@ func (ses *Session) open(ctx context.Context) error {
 	ses.conn, err = new(net.Dialer).DialContext(ctx, network, address)
 	var opErr *net.OpError
 	if errors.As(err, &opErr) {
-		opErr.Err = fmt.Errorf(strings.Replace(opErr.Err.Error(), "connect: ", "", -1))
-		return mysqlerrors.New(errCode, opErr.Addr, opErr)
+		return mysqlerrors.New(errCode, opErr.Addr,
+			fmt.Errorf(strings.Replace(opErr.Err.Error(), "connect: ", "", -1)))
 	}
 
 	defer func() {

--- a/xmysql/session_test.go
+++ b/xmysql/session_test.go
@@ -341,6 +341,7 @@ func TestSession_SetTimeZone(t *testing.T) {
 
 		// without time location set, timestamps returned by MySQL are UTC
 		nowUSALA := time.Now().In(locUSALA)
+		time.Sleep(1 * time.Second)
 		res, err := ses.ExecuteStatement(context.Background(), "SELECT NOW(6)")
 		xt.OK(t, err)
 


### PR DESCRIPTION
Previously, it was not possible to use and address without a port. Doing
so would have set the host-part always back to the default.

We know correctly handle connection address without port, using default
port (33060). Cases are now properly tested.