### PR TITLE
fix: recover from server timing out connections

### DIFF
--- a/xmysql/notice.go
+++ b/xmysql/notice.go
@@ -5,8 +5,6 @@ package xmysql
 import (
 	"fmt"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/golistic/pxmysql/internal/mysqlx/mysqlxnotice"
 )
 
@@ -48,7 +46,7 @@ func (n *notices) add(msg *serverMessage) error {
 		n.sessionVariableChanges = append(n.sessionVariableChanges, m)
 	case mysqlxnotice.Frame_SESSION_STATE_CHANGED:
 		m := &mysqlxnotice.SessionStateChanged{}
-		if err := proto.Unmarshal(frame.Payload, m); err != nil {
+		if err := UnmarshalPartial(frame.Payload, m); err != nil {
 			return fmt.Errorf("failed unmarshalling '%s' (%w)", m.String(), err)
 		}
 		trace("state", m)

--- a/xmysql/proto.go
+++ b/xmysql/proto.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package xmysql
+
+import (
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+)
+
+// UnmarshalPartial parses the wire-format message in b and places the result in m.
+// The provided message must be mutable (e.g., a non-nil pointer to a message).
+// This is the same function as proto.Unmarshall except that AllowPartial option set to true.
+func UnmarshalPartial(b []byte, m proto.Message) error {
+	return proto.UnmarshalOptions{
+		RecursionLimit: protowire.DefaultRecursionLimit,
+		AllowPartial:   true,
+	}.Unmarshal(b, m)
+}


### PR DESCRIPTION
When `mysqlx_wait_timeout` is reached, the MySQL X Plugin will close the inactive session. We did not correctly recover from this. We fix it by sending the `driver.ErrBadConn` when the header of a message could not be read.

We also implement `xmysql.UnmarshalPartial` which is the same as `proto.Unmarshall` but with `AllowPartial` set `true`.

Fixes #22