### PR TITLE
fix: handling too large packets

### DIFF
--- a/mysqlerrors/error_client.go
+++ b/mysqlerrors/error_client.go
@@ -36,7 +36,7 @@ var mysqlClientErrors = map[int]Error{
 		SQLState: "HY000",
 	},
 	ClientNetPacketTooLarge: { // 2020
-		Message:  "got packet bigger than 'max_allowed_packet' bytes",
+		Message:  "got packet bigger than 'mysqlx_max_allowed_packet' bytes",
 		Code:     ClientNetPacketTooLarge,
 		SQLState: "HY000",
 	},

--- a/xmysql/_testdata/data_types_string.sql
+++ b/xmysql/_testdata/data_types_string.sql
@@ -26,7 +26,7 @@ VALUES (1,
         CONCAT('VARCHAR', REPEAT('b', 393)),
         X'0708090a0b0c0d0e0f10',
         X'08090a0b0c0d0e0f10',
-        CONCAT('LONGTEXT', REPEAT('l', @@max_allowed_packet - 10)),
+        CONCAT('LONGTEXT', REPEAT('l', @@mysqlx_max_allowed_packet - 10)),
         'I am a tiny blob',
         'Go',
         'Python,Go');

--- a/xmysql/main_test.go
+++ b/xmysql/main_test.go
@@ -19,7 +19,7 @@ var (
 )
 
 var (
-	testMySQLMaxAllowedPacket = -1 // MySQL's @@max_allowed_packet
+	testMySQLMaxAllowedPacket = -1 // MySQL's mysqlx_max_allowed_packet
 )
 
 func testTearDown() {
@@ -51,13 +51,13 @@ func TestMain(m *testing.M) {
 		return
 	}
 
-	if v, err := testContext.Server.Variable("global", "max_allowed_packet"); err != nil {
-		testErr = fmt.Errorf("failed getting variable max_allowed_packet (%s)", err)
+	if v, err := testContext.Server.Variable("global", "mysqlx_max_allowed_packet"); err != nil {
+		testErr = fmt.Errorf("failed getting variable mysqlx_max_allowed_packet (%s)", err)
 		return
 	} else {
 		n, err := strconv.ParseInt(v, 10, 32)
 		if err != nil {
-			testErr = fmt.Errorf("failed converting variable max_allowed_packet (%s)", err)
+			testErr = fmt.Errorf("failed converting variable mysqlx_max_allowed_packet (%s)", err)
 			return
 		}
 		testMySQLMaxAllowedPacket = int(n)

--- a/xmysql/prepared_test.go
+++ b/xmysql/prepared_test.go
@@ -260,10 +260,7 @@ func TestPrepared_Execute(t *testing.T) {
 		xt.Eq(t, mysqlerrors.ClientNetPacketTooLarge, errMySQL.Code)
 
 		_, err = prepSelect.Execute(context.Background(), "ok length")
-		// connection was re-opened
-		xt.KO(t, err)
-		xt.Assert(t, errors.As(err, &errMySQL))
-		xt.Eq(t, 5110, errMySQL.Code)
+		xt.OK(t, err)
 	})
 
 	t.Run("big but ok length message", func(t *testing.T) {


### PR DESCRIPTION
The MySQL X Plugin does not report whether a packet is too big. It instead simply closes the connection and the client cannot figure out what the problem was.

We fix this by getting the `mysqlx_max_allowed_packet` value and check the message size before writing it to the server.

Fixes #28