### PR TITLE
fix: pxmysql.QueryContext() returns no error if no rows

### DIFF
--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="SqlDialectMappings">
-    <file url="file://$APPLICATION_CONFIG_DIR$/scratches/scratch_13.go" dialect="GenericSQL" />
     <file url="file://$PROJECT_DIR$/xmysql/session_test.go" dialect="GenericSQL" />
     <file url="PROJECT" dialect="MySQL" />
   </component>

--- a/connection_test.go
+++ b/connection_test.go
@@ -67,9 +67,9 @@ func TestConnection_Begin(t *testing.T) {
 		xt.OK(t, tx.Rollback())
 
 		q := fmt.Sprintf("SELECT c1 FROM `%s` WHERE id = ?", tbl)
-		_, err = db.QueryContext(context.Background(), q, id)
-		xt.KO(t, err)
-		xt.Eq(t, err.Error(), sql.ErrNoRows.Error())
+		rows, err := db.QueryContext(context.Background(), q, id)
+		xt.OK(t, err)
+		xt.Assert(t, !rows.Next())
 	})
 }
 
@@ -124,8 +124,6 @@ func TestConnector_Connect(t *testing.T) {
 		time.Sleep(3 * time.Second) // server should close connection
 
 		var cnxIDAfter int
-		db.QueryRow("SELECT CONNECTION_ID()").Scan(&cnxIDAfter)
-
 		xt.OK(t, db.QueryRow("SELECT CONNECTION_ID()").Scan(&cnxIDAfter))
 
 		xt.Assert(t, cnxID != cnxIDAfter)

--- a/rows.go
+++ b/rows.go
@@ -38,7 +38,7 @@ func (r *rows) Close() error {
 }
 
 func (r *rows) Next(dest []driver.Value) error {
-	if r.currRowIndex >= len(r.xpresult.Rows) {
+	if r.xpresult == nil || r.currRowIndex >= len(r.xpresult.Rows) {
 		return io.EOF
 	}
 

--- a/statement.go
+++ b/statement.go
@@ -4,7 +4,6 @@ package pxmysql
 
 import (
 	"context"
-	"database/sql"
 	"database/sql/driver"
 	"time"
 
@@ -103,7 +102,7 @@ func (s *statement) QueryContext(ctx context.Context, args []driver.NamedValue) 
 	}
 
 	if len(execResult.Rows) == 0 {
-		return nil, sql.ErrNoRows
+		return &rows{}, nil
 	}
 
 	r := &rows{


### PR DESCRIPTION
We make sure that `pxmysql.QueryContext()` does not return an error when there were no rows in the result set.

We added the missing tests, and also test to make sure `pxmysql.QueryRowContext()` returns `sql.ErrNoRows` (because it should).

Fixes #35