### PR TITLE
feat(driver!): register drivers pxmysql and mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ import (
 )
 
 func main() {
-	db, err := sql.Open("mysqlpx", "scott:tiger@tcp(127.0.0.1:33060)/somedb?useTLS=true")
+	// can use pxmysql or mysql as driver name
+	db, err := sql.Open("mysql", "scott:tiger@tcp(127.0.0.1:33060)/somedb?useTLS=true")
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -250,6 +251,15 @@ The `ConnectConfig`-type has the following attributes:
 * `TimeZoneName`: set time location for decoding DATETIME and TIMESTAMP MySQL
   data types to Go `time.Time` (see [MySQL Manual to support this][2])
   (default: UTC)
+
+### Environment Variables
+
+The following lists environment variables that can be set to configure the `pxmysql`
+package.
+
+* `PXMYSQL_DONT_REGISTER_MYSQL`: use this to not register the name `mysql` as driver.
+  This can be handy when you want to use both the [conventional driver][3] and the driver
+  of this package.
 
 ### Authentication methods
 

--- a/_support/pxmysql-compose/shared/goapps/unix_socket/main.go
+++ b/_support/pxmysql-compose/shared/goapps/unix_socket/main.go
@@ -22,7 +22,7 @@ import (
 
 func main() {
 	// credentials are the once used when running pxmysql tests
-	db, err := sql.Open("mysqlpx", "root:rootpwd@unix(/var/lib/mysql/mysqlx.sock)")
+	db, err := sql.Open("pxmysql", "root:rootpwd@unix(/var/lib/mysql/mysqlx.sock)")
 	if err != nil {
 		log.Fatalln("open:", err)
 	}

--- a/connection_test.go
+++ b/connection_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestConnection_Begin(t *testing.T) {
 	dsn := getTCPDSN()
-	db, err := sql.Open("mysqlpx", dsn)
+	db, err := sql.Open("pxmysql", dsn)
 	xt.OK(t, err)
 	defer func() { _ = db.Close() }()
 
@@ -75,7 +75,7 @@ func TestConnection_Begin(t *testing.T) {
 
 func TestConnection_ExecContext(t *testing.T) {
 	dsn := getTCPDSN()
-	db, err := sql.Open("mysqlpx", dsn)
+	db, err := sql.Open("pxmysql", dsn)
 	xt.OK(t, err)
 	defer func() { _ = db.Close() }()
 
@@ -91,7 +91,7 @@ func TestConnection_ExecContext(t *testing.T) {
 
 func TestConnection_QueryContext(t *testing.T) {
 	dsn := getTCPDSN()
-	db, err := sql.Open("mysqlpx", dsn)
+	db, err := sql.Open("pxmysql", dsn)
 	xt.OK(t, err)
 	defer func() { _ = db.Close() }()
 
@@ -108,7 +108,7 @@ func TestConnection_QueryContext(t *testing.T) {
 func TestConnector_Connect(t *testing.T) {
 	t.Run("server closing stale connection and reconnect", func(t *testing.T) {
 		dsn := getTCPDSN()
-		db, err := sql.Open("mysqlpx", dsn)
+		db, err := sql.Open("pxmysql", dsn)
 		xt.OK(t, err)
 
 		_, err = db.Exec("SET @@SESSION.mysqlx_wait_timeout = 2")

--- a/driver.go
+++ b/driver.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"os"
 )
 
-const driverName = "mysqlpx"
+const driverName = "pxmysql"
+const driverNameMySQL = "mysql"
 
 type Driver struct{}
 
@@ -19,6 +21,10 @@ var (
 
 func init() {
 	sql.Register(driverName, &Driver{})
+
+	if s, ok := os.LookupEnv("PXMYSQL_DONT_REGISTER_MYSQL"); !ok || s != "1" {
+		sql.Register(driverNameMySQL, &Driver{})
+	}
 }
 
 // Open returns a new connection to the MySQL database using MySQL X Protocol.

--- a/driver_test.go
+++ b/driver_test.go
@@ -9,13 +9,24 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"testing"
 
+	"github.com/golistic/xstrings"
 	"github.com/golistic/xt"
 
 	"github.com/golistic/pxmysql/internal/xxt"
 	"github.com/golistic/pxmysql/mysqlerrors"
 )
+
+func testCmd(cmdArgs []string, envs []string) *exec.Cmd {
+	args := append([]string{"-test.v"}, cmdArgs...)
+
+	cmd := exec.Command(os.Args[0], args...)
+	cmd.Env = append(os.Environ(), envs...)
+
+	return cmd
+}
 
 func TestSQLDriver_Open(t *testing.T) {
 	pwd := "aPassword"
@@ -60,7 +71,7 @@ func TestSQLDriver_Open(t *testing.T) {
 		xt.OK(t, err)
 
 		dsn := getTCPDSN("", "")
-		db, err := sql.Open("mysqlpx", dsn)
+		db, err := sql.Open("pxmysql", dsn)
 
 		t.Run("using Prepared Statement", func(t *testing.T) {
 			xt.OK(t, err)
@@ -122,5 +133,38 @@ func TestConnection_Ping(t *testing.T) {
 		xt.KO(t, errors.Unwrap(err))
 		xt.Eq(t, "no such file or directory", errors.Unwrap(err).Error())
 	})
+}
 
+func TestDriver_Open(t *testing.T) {
+	t.Run("pxmysql is registered", func(t *testing.T) {
+		xt.Assert(t, xstrings.SliceHas(sql.Drivers(), "pxmysql"), "expected driver pxmysql to be registered")
+	})
+
+	t.Run("mysql is registered", func(t *testing.T) {
+		xt.Assert(t, xstrings.SliceHas(sql.Drivers(), "mysql"), "expected driver mysql to be registered")
+	})
+
+	t.Run("mysql is not registered", func(t *testing.T) {
+		// executes test 'check for mysql name in drivers' in its own subprocess
+		args := []string{
+			"-test.run", `^\QTestDriver_Open\E$/^\Qcheck_for_mysql_name_in_drivers\E$`,
+		}
+
+		cmd := testCmd(args, []string{"PXMYSQL_DONT_REGISTER_MYSQL=1", "CHECK=1"})
+		xt.OK(t, cmd.Run(), "PXMYSQL_DONT_REGISTER_MYSQL might not be correctly interpreted")
+	})
+
+	t.Run("check for mysql name in drivers", func(t *testing.T) {
+		// this is executed in a subprocess
+		if _, ok := os.LookupEnv("CHECK"); !ok {
+			// no need to report this as skipped
+			return
+		}
+
+		s, ok := os.LookupEnv("PXMYSQL_DONT_REGISTER_MYSQL")
+		xt.Assert(t, ok, "expected PXMYSQL_DONT_REGISTER_MYSQL to be set")
+		xt.Eq(t, "1", s, "expected PXMYSQL_DONT_REGISTER_MYSQL to be set to '1'")
+		xt.Assert(t, !xstrings.SliceHas(sql.Drivers(), "mysql"),
+			"expected driver mysql to be NOT registered")
+	})
 }

--- a/statement_test.go
+++ b/statement_test.go
@@ -21,7 +21,7 @@ import (
 
 func TestStatement_Close(t *testing.T) {
 	dsn := getTCPDSN("", "")
-	db, err := sql.Open("mysqlpx", dsn)
+	db, err := sql.Open("pxmysql", dsn)
 	xt.OK(t, err)
 
 	stmt := "SELECT ?"
@@ -40,7 +40,7 @@ func TestStatement_Close(t *testing.T) {
 
 func testOpenQueryRowsClose() ([]string, error) {
 	dsn := getTCPDSN("", "")
-	db, err := sql.Open("mysqlpx", dsn)
+	db, err := sql.Open("pxmysql", dsn)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func testOpenQueryRowsClose() ([]string, error) {
 func TestStatement_ExecContext(t *testing.T) {
 	t.Run("respect timeout", func(t *testing.T) {
 		dsn := getTCPDSN("", "")
-		db, err := sql.Open("mysqlpx", dsn)
+		db, err := sql.Open("pxmysql", dsn)
 		xt.OK(t, err)
 		defer func() { _ = db.Close() }()
 
@@ -109,7 +109,7 @@ func TestStatement_QueryContext(t *testing.T) {
 
 	t.Run("respect timeout", func(t *testing.T) {
 		dsn := getTCPDSN("", "")
-		db, err := sql.Open("mysqlpx", dsn)
+		db, err := sql.Open("pxmysql", dsn)
 		xt.OK(t, err)
 		defer func() { _ = db.Close() }()
 
@@ -122,7 +122,7 @@ func TestStatement_QueryContext(t *testing.T) {
 	})
 
 	t.Run("does not return sql.ErrNoRows", func(t *testing.T) {
-		db, err := sql.Open("mysqlpx", getTCPDSN("", ""))
+		db, err := sql.Open("pxmysql", getTCPDSN("", ""))
 		xt.OK(t, err)
 		defer func() { _ = db.Close() }()
 
@@ -133,7 +133,7 @@ func TestStatement_QueryContext(t *testing.T) {
 	})
 
 	t.Run("QueryRowContext does return sql.ErrNoRows", func(t *testing.T) {
-		db, err := sql.Open("mysqlpx", getTCPDSN("", ""))
+		db, err := sql.Open("pxmysql", getTCPDSN("", ""))
 		xt.OK(t, err)
 		defer func() { _ = db.Close() }()
 


### PR DESCRIPTION
We register both the `pxmysql` and `mysql` driver names. This makes it a bit easier to use. The driver name is really the "dialect".

If for any reason one wants to use another driver registering 'mysql', the registration can be disabled using following environment variable (value must be "1"):

    PXMYSQL_DONT_REGISTER_MYSQL=1

BREAKING CHANGE:
Previously, we used the driver name `mysqlpx`. This was different from the package name, and since it even confused the author, we renamed it back as `pxmysql`. Since we have not released a production version we allow ourselves to be not backwards compatible. Users must adapt.

Fixes #34