### PR TITLE
feat(driver!): use mysql driver name by importing sub-package

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,13 @@ import (
 	"log"
 
 	_ "github.com/golistic/pxmysql"
+	
+	// or import the following to use the driver name "mysql"
+	// _ "github.com/golistic/pxmysql/mysql"
 )
 
 func main() {
-	// can use pxmysql or mysql as driver name
-	db, err := sql.Open("mysql", "scott:tiger@tcp(127.0.0.1:33060)/somedb?useTLS=true")
+	db, err := sql.Open("pxmysql", "scott:tiger@tcp(127.0.0.1:33060)/somedb?useTLS=true")
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -252,14 +254,22 @@ The `ConnectConfig`-type has the following attributes:
   data types to Go `time.Time` (see [MySQL Manual to support this][2])
   (default: UTC)
 
-### Environment Variables
+### Driver name
 
-The following lists environment variables that can be set to configure the `pxmysql`
-package.
+We use the driver name "pxmysql", which needs to be used with Go's `sql.Open`.
+However, some projects require the "mysql" name, but can use this driver instead.
+Therefor, you can register "mysql" to use the `pxmysql` driver like this:
 
-* `PXMYSQL_DONT_REGISTER_MYSQL`: use this to not register the name `mysql` as driver.
-  This can be handy when you want to use both the [conventional driver][3] and the driver
-  of this package.
+```go
+package yourstuff
+
+import (
+    _ "github.com/golistic/pxmysql/mysql"
+)
+```
+
+We do not default to "mysql" as driver name, so it is possible to use
+other drivers using MySQL at the same time.
 
 ### Authentication methods
 

--- a/driver.go
+++ b/driver.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, Geert JM Vanderkelen
+// Copyright (c) 2022, 2023, Geert JM Vanderkelen
 
 package pxmysql
 
@@ -6,11 +6,9 @@ import (
 	"context"
 	"database/sql"
 	"database/sql/driver"
-	"os"
 )
 
 const driverName = "pxmysql"
-const driverNameMySQL = "mysql"
 
 type Driver struct{}
 
@@ -21,10 +19,6 @@ var (
 
 func init() {
 	sql.Register(driverName, &Driver{})
-
-	if s, ok := os.LookupEnv("PXMYSQL_DONT_REGISTER_MYSQL"); !ok || s != "1" {
-		sql.Register(driverNameMySQL, &Driver{})
-	}
 }
 
 // Open returns a new connection to the MySQL database using MySQL X Protocol.

--- a/driver_test.go
+++ b/driver_test.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/golistic/xstrings"
@@ -18,15 +17,6 @@ import (
 	"github.com/golistic/pxmysql/internal/xxt"
 	"github.com/golistic/pxmysql/mysqlerrors"
 )
-
-func testCmd(cmdArgs []string, envs []string) *exec.Cmd {
-	args := append([]string{"-test.v"}, cmdArgs...)
-
-	cmd := exec.Command(os.Args[0], args...)
-	cmd.Env = append(os.Environ(), envs...)
-
-	return cmd
-}
 
 func TestSQLDriver_Open(t *testing.T) {
 	pwd := "aPassword"
@@ -140,31 +130,7 @@ func TestDriver_Open(t *testing.T) {
 		xt.Assert(t, xstrings.SliceHas(sql.Drivers(), "pxmysql"), "expected driver pxmysql to be registered")
 	})
 
-	t.Run("mysql is registered", func(t *testing.T) {
-		xt.Assert(t, xstrings.SliceHas(sql.Drivers(), "mysql"), "expected driver mysql to be registered")
-	})
-
 	t.Run("mysql is not registered", func(t *testing.T) {
-		// executes test 'check for mysql name in drivers' in its own subprocess
-		args := []string{
-			"-test.run", `^\QTestDriver_Open\E$/^\Qcheck_for_mysql_name_in_drivers\E$`,
-		}
-
-		cmd := testCmd(args, []string{"PXMYSQL_DONT_REGISTER_MYSQL=1", "CHECK=1"})
-		xt.OK(t, cmd.Run(), "PXMYSQL_DONT_REGISTER_MYSQL might not be correctly interpreted")
-	})
-
-	t.Run("check for mysql name in drivers", func(t *testing.T) {
-		// this is executed in a subprocess
-		if _, ok := os.LookupEnv("CHECK"); !ok {
-			// no need to report this as skipped
-			return
-		}
-
-		s, ok := os.LookupEnv("PXMYSQL_DONT_REGISTER_MYSQL")
-		xt.Assert(t, ok, "expected PXMYSQL_DONT_REGISTER_MYSQL to be set")
-		xt.Eq(t, "1", s, "expected PXMYSQL_DONT_REGISTER_MYSQL to be set to '1'")
-		xt.Assert(t, !xstrings.SliceHas(sql.Drivers(), "mysql"),
-			"expected driver mysql to be NOT registered")
+		xt.Assert(t, !xstrings.SliceHas(sql.Drivers(), "mysql"), "expected driver mysql to be NOT registered")
 	})
 }

--- a/mysql/register.go
+++ b/mysql/register.go
@@ -1,0 +1,13 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package mysql
+
+import (
+	"database/sql"
+
+	"github.com/golistic/pxmysql"
+)
+
+func init() {
+	sql.Register("mysql", &pxmysql.Driver{})
+}

--- a/mysql/register_test.go
+++ b/mysql/register_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package mysql
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/golistic/xstrings"
+	"github.com/golistic/xt"
+)
+
+func TestDriver_Open(t *testing.T) {
+	t.Run("pxmysql is registered", func(t *testing.T) {
+		xt.Assert(t, xstrings.SliceHas(sql.Drivers(), "pxmysql"), "expected driver pxmysql to be registered")
+	})
+
+	t.Run("mysql is registered", func(t *testing.T) {
+		xt.Assert(t, xstrings.SliceHas(sql.Drivers(), "mysql"), "expected driver mysql to be registered")
+	})
+}


### PR DESCRIPTION
We remove the need to set an environment variable to _not_ register the "mysql" driver name. Instead, if you really need that name, you can now import the sub-package `github.com/golistic/pxmysql/mysql` and then you can do:

    	db, err := sql.Open("mysql", "u:p@tcp(127.0.0.1:33060)/")

BREAKING CHANGE:
Since we now can explicitly define which driver name to use, we do not need the environment variable any longer. Since "mysql" is not registered by default any longer, users must now use the anonymous import `github.com/golistic/pxmysql/mysql` instead.

Resolves #39