### PR TITLE
fix(driver): properly dealloc prepared statement

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -89,6 +89,8 @@ func (c *connection) ExecContext(ctx context.Context, query string, args []drive
 		return nil, handleError(err)
 	}
 
+	defer func() { _ = prep.Deallocate(ctx) }()
+
 	stmt := &statement{
 		prepared: prep,
 	}
@@ -101,6 +103,8 @@ func (c *connection) QueryContext(ctx context.Context, query string, args []driv
 	if err != nil {
 		return nil, handleError(err)
 	}
+
+	defer func() { _ = prep.Deallocate(ctx) }()
 
 	stmt := &statement{
 		prepared: prep,

--- a/rows_test.go
+++ b/rows_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package pxmysql
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golistic/xt"
+)
+
+func TestRows_Next(t *testing.T) {
+	db, err := sql.Open("pxmysql", getTCPDSN("", ""))
+	xt.OK(t, err)
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+
+	t.Run("time.Time", func(t *testing.T) {
+		tbl := "test_data_types_null_time"
+		_, err := db.ExecContext(ctx, fmt.Sprintf("CREATE TABLE `%s` (id int, ts DATETIME NULL)", tbl))
+		xt.OK(t, err)
+
+		_, err = db.ExecContext(ctx, fmt.Sprintf(
+			"INSERT INTO `%s` (id, ts) VALUE (1, NOW()),(2, NULL)", tbl))
+		xt.OK(t, err)
+
+		stmt := fmt.Sprintf("SELECT ts FROM `%s` WHERE id = ?", tbl)
+
+		var ts time.Time
+		xt.OK(t, db.QueryRowContext(ctx, stmt, 1).Scan(&ts))
+
+		var tsNull sql.NullTime
+		xt.OK(t, db.QueryRowContext(ctx, stmt, 2).Scan(&tsNull))
+	})
+}


### PR DESCRIPTION
We properly deallocate prepared statements when using the connection methods ExecContext and QueryContext (which includes QueryRowContext). This prevents reaching `max_prepared_stmt_count`, meaning we do not leak any longer.

Fixes #44