### PR TITLE
refactor(driver)!: move driver registration to sub-packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Copyright (c) 2022, 2023, Geert JM Vanderkelen
   <img alt="license: MIT" src="_badges/license.svg">
 </div>
 
-The Go pxmysql package implements the MySQL X Protocol and provides a Go sql
-driver which uses it. The X Protocol communicates with MySQL using a different
-TCP port and transfers data using Protocol Buffers.
+The Go pxmysql package implements the MySQL X Protocol and provides a Go `sql/driver`
+which uses it. The X Protocol communicates with MySQL using TCP port 33060 (default)
+using structured data serialized using Protocol Buffers.
 
 Note that the MySQL X Protocol is an alternative, an extension of the
 conventional well known text-based MySQL protocol.  
@@ -39,10 +39,10 @@ import (
 	"fmt"
 	"log"
 
-	_ "github.com/golistic/pxmysql"
+	_ "github.com/golistic/pxmysql/register"
 	
 	// or import the following to use the driver name "mysql"
-	// _ "github.com/golistic/pxmysql/mysql"
+	// _ "github.com/golistic/pxmysql/register/mysql"
 )
 
 func main() {
@@ -256,14 +256,27 @@ The `ConnectConfig`-type has the following attributes:
 ### Driver name
 
 We use the driver name "pxmysql", which needs to be used with Go's `sql.Open`.
-However, some projects require the "mysql" name, but can use this driver instead.
-Therefor, you can register "mysql" to use the `pxmysql` driver like this:
+To register the driver, you use an anonymous import as follows:
 
 ```go
 package yourstuff
 
 import (
-    _ "github.com/golistic/pxmysql/mysql"
+    _ "github.com/golistic/pxmysql/register"
+)
+```
+
+Note the extra sub-package, which is different from other drivers. We do like to
+explicitly load, and not register whenever the driver is imported.
+
+Some projects require the "mysql" name to be registered, using the driver name
+as a SQL dialect. This can be achieved by using the sub-package `register/mysql`:
+
+```go
+package yourstuff
+
+import (
+    _ "github.com/golistic/pxmysql/register/mysql"
 )
 ```
 

--- a/_support/pxmysql-compose/shared/goapps/unix_socket/main.go
+++ b/_support/pxmysql-compose/shared/goapps/unix_socket/main.go
@@ -17,7 +17,7 @@ import (
 	"fmt"
 	"log"
 
-	_ "github.com/golistic/pxmysql"
+	_ "github.com/golistic/pxmysql/register"
 )
 
 func main() {

--- a/connection_test.go
+++ b/connection_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Geert JM Vanderkelen
 
-package pxmysql
+package pxmysql_test
 
 import (
 	"context"

--- a/driver.go
+++ b/driver.go
@@ -4,11 +4,8 @@ package pxmysql
 
 import (
 	"context"
-	"database/sql"
 	"database/sql/driver"
 )
-
-const driverName = "pxmysql"
 
 type Driver struct{}
 
@@ -16,10 +13,6 @@ var (
 	_ driver.Driver        = &Driver{}
 	_ driver.DriverContext = &Driver{}
 )
-
-func init() {
-	sql.Register(driverName, &Driver{})
-}
 
 // Open returns a new connection to the MySQL database using MySQL X Protocol.
 func (d *Driver) Open(name string) (driver.Conn, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,15 +1,16 @@
 // Copyright (c) 2022, Geert JM Vanderkelen
 
-package pxmysql
+package pxmysql_test
 
 import (
-	"context"
-	"database/sql/driver"
+	"database/sql"
 	"fmt"
 	"os"
 	"testing"
 
 	"github.com/golistic/xgo/xt"
+
+	_ "github.com/golistic/pxmysql/register" // registers pxmysql
 
 	"github.com/golistic/pxmysql/internal/xxt"
 )
@@ -67,20 +68,15 @@ func getTCPDSN(credentials ...string) string {
 		testSchema)
 }
 
-func cnxType(t *testing.T, conn driver.Conn) string {
+func cnxType(t *testing.T, db *sql.DB) string {
 	t.Helper()
 
 	q := "SELECT IF(HOST='localhost', 'unix', 'tcp') As CnxType " +
 		"FROM performance_schema.processlist WHERE ID = CONNECTION_ID()"
 
-	cnx, ok := conn.(*connection)
-	xt.Assert(t, ok, "bad connection")
-
-	result, err := cnx.session.ExecuteStatement(context.Background(), q)
+	var ct string
+	err := db.QueryRow(q).Scan(&ct)
 	xt.OK(t, err)
 
-	for _, row := range result.Rows {
-		return row.Values[0].(string)
-	}
-	return ""
+	return ct
 }

--- a/register/mysql/register.go
+++ b/register/mysql/register.go
@@ -8,6 +8,8 @@ import (
 	"github.com/golistic/pxmysql"
 )
 
+const DriverName = "mysql"
+
 func init() {
-	sql.Register("mysql", &pxmysql.Driver{})
+	sql.Register(DriverName, &pxmysql.Driver{})
 }

--- a/register/mysql/register_test.go
+++ b/register/mysql/register_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package mysql
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/golistic/xgo/xstrings"
+	"github.com/golistic/xgo/xt"
+)
+
+func TestDriver_Open(t *testing.T) {
+	t.Run("pxmysql is not registered", func(t *testing.T) {
+		xt.Assert(t, !xstrings.SliceHas(sql.Drivers(), "pxmysql"), "expected driver pxmysql not to be registered")
+	})
+
+	t.Run("mysql is registered", func(t *testing.T) {
+		xt.Assert(t, xstrings.SliceHas(sql.Drivers(), "mysql"), "expected driver mysql to be registered")
+	})
+}

--- a/register/register.go
+++ b/register/register.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package register
+
+import (
+	"database/sql"
+
+	"github.com/golistic/pxmysql"
+)
+
+const DriverName = "pxmysql"
+
+func init() {
+	sql.Register(DriverName, &pxmysql.Driver{})
+}

--- a/register/register_test.go
+++ b/register/register_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2023, Geert JM Vanderkelen
 
-package mysql
+package register
 
 import (
 	"database/sql"
@@ -15,7 +15,7 @@ func TestDriver_Open(t *testing.T) {
 		xt.Assert(t, xstrings.SliceHas(sql.Drivers(), "pxmysql"), "expected driver pxmysql to be registered")
 	})
 
-	t.Run("mysql is registered", func(t *testing.T) {
-		xt.Assert(t, xstrings.SliceHas(sql.Drivers(), "mysql"), "expected driver mysql to be registered")
+	t.Run("mysql is not registered", func(t *testing.T) {
+		xt.Assert(t, !xstrings.SliceHas(sql.Drivers(), "mysql"), "expected driver mysql not to be registered")
 	})
 }

--- a/rows_test.go
+++ b/rows_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2023, Geert JM Vanderkelen
 
-package pxmysql
+package pxmysql_test
 
 import (
 	"context"

--- a/statement_test.go
+++ b/statement_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2022, Geert JM Vanderkelen
 
-package pxmysql
+package pxmysql_test
 
 import (
 	"context"


### PR DESCRIPTION
We remove the init-function which registers the SQL driver when importing the main package `github.com/golistic/pxmysql`. Now, users must register (if wanted), using `github.com/golistic/pxmysql/register`.

If the "mysql" driver name needs to be registered, users can anonymously import `github.com/golistic/pxmysql/register/mysql`.

BREAKING CHANGING:
With moving the registration to sub-packages, users will need to import (anonymously) `github.com/golistic/pxmysql/register`. We do not keep backwards compatibility.

Resolves #50