### PR TITLE
feat(xmysql)!: add Schema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,31 @@ heading (bit like a roadmap).
     - [x] Test MySQL String data types
     - [x] Test MySQL Decimal data type
     - [ ] MySQL to Go types
-* [ ] Collections
-    - [ ] Create & Ensure
-    - [ ] Drop
+* [ ] MySQL X DevAPI
+    - [ ] Session
+      - [x] Get active and default schema
+      - [x] Get schema using name
+      - [x] Get list of available schemas (databases)
+      - [x] Create/Drop schema
+      - ..
+    - [ ] Schema
+      - [x] Get name
+      - [ ] Get list of available collections (tables)
+      - [ ] Get collection
+      - [ ] Get list of collections
+    - [ ] Collection
+      - [ ] Exists in database
+      - [ ] Add document
+      - [ ] Get document by ID
+      - [ ] Add or replace document
+      - [ ] Count of documents in collection
+      - [ ] Creating and dropping indices
+      - [ ] Retrieve documents
+      - [ ] Modify documents
+      - [ ] Remove one or more documents
+      - [ ] Replace document
+    - [ ] Table
+    - [ ] View
 * [ ] Use Prepared Statement
     - [x] Type `statement` (the conventional SQL PREPARE)
     - [ ] CRUD operations: types `INSERT`, `FIND`, and `DELETE`

--- a/xmysql/_testdata/base.sql
+++ b/xmysql/_testdata/base.sql
@@ -1,19 +1,21 @@
 CREATE SCHEMA IF NOT EXISTS pxmysql_tests;
-
-/*
- * Copyright (c) 2022, Geert JM Vanderkelen
- */
+CREATE SCHEMA IF NOT EXISTS pxmysql_tests_a;
 
 -- Following users are used for testing the authentication with
 -- MySQL Authentication Plugins.
 CREATE USER IF NOT EXISTS 'user_native'@'%' IDENTIFIED WITH mysql_native_password
     BY 'pwd_user_native';
 GRANT ALL ON pxmysql_tests.* TO 'user_native'@'%';
+GRANT ALL ON pxmysql_tests_a.* TO 'user_native'@'%';
 
 CREATE USER IF NOT EXISTS 'user_sha256'@'%' IDENTIFIED WITH caching_sha2_password
     BY 'pwd_user_sha256';
 GRANT ALL ON pxmysql_tests.* TO 'user_sha256'@'%';
+GRANT ALL ON pxmysql_tests_a.* TO 'user_sha256'@'%';
 
--- Basic users for testing.
 CREATE USER IF NOT EXISTS 'pxmysqltest'@'%' IDENTIFIED WITH mysql_native_password BY '';
 GRANT ALL ON pxmysql_tests.* TO 'pxmysqltest'@'%';
+GRANT ALL ON pxmysql_tests_a.* TO 'pxmysqltest'@'%';
+
+-- Clean up objects that might have been created by tests
+DROP SCHEMA IF EXISTS `pxmysql_2839cks829dka`;

--- a/xmysql/_testdata/data_types_datetime.sql
+++ b/xmysql/_testdata/data_types_datetime.sql
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2022, Geert JM Vanderkelen
- */
-
 USE pxmysql_tests;
 
 DROP TABLE IF EXISTS `data_types_datetime`;

--- a/xmysql/_testdata/data_types_numeric.sql
+++ b/xmysql/_testdata/data_types_numeric.sql
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2022, Geert JM Vanderkelen
- */
-
 USE pxmysql_tests;
 
 DROP TABLE IF EXISTS `data_types_numeric`;

--- a/xmysql/_testdata/data_types_string.sql
+++ b/xmysql/_testdata/data_types_string.sql
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2022, Geert JM Vanderkelen
- */
-
 USE pxmysql_tests;
 
 DROP TABLE IF EXISTS `data_types_string`;

--- a/xmysql/_testdata/inserting.sql
+++ b/xmysql/_testdata/inserting.sql
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2022, Geert JM Vanderkelen
- */
-
 USE pxmysql_tests;
 
 DROP TABLE IF EXISTS `inserts01`;

--- a/xmysql/_testdata/prepared_stmt.sql
+++ b/xmysql/_testdata/prepared_stmt.sql
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) 2022, Geert JM Vanderkelen
- */
-
 USE pxmysql_tests;
 
 DROP TABLE IF EXISTS `numeric_not_null`, `numeric_null`;

--- a/xmysql/defaults.go
+++ b/xmysql/defaults.go
@@ -4,6 +4,16 @@ package xmysql
 
 const authChallengeLen = 20
 
+const (
+	AuthMethodPlain        AuthMethodType = "PLAIN"
+	AuthMethodAuto         AuthMethodType = "AUTO"
+	AuthMethodSHA256Memory AuthMethodType = "SHA256_MEMORY"
+	AuthMethodMySQL41      AuthMethodType = "MYSQL41"
+)
+
+const DefaultPort = "33060"
+const DefaultHost = "127.0.0.1"
+
 type AuthMethodType string
 
 type AuthMethodTypes []AuthMethodType
@@ -16,13 +26,6 @@ func (a AuthMethodTypes) Has(m AuthMethodType) bool {
 	}
 	return false
 }
-
-const (
-	AuthMethodPlain        AuthMethodType = "PLAIN"
-	AuthMethodAuto         AuthMethodType = "AUTO"
-	AuthMethodSHA256Memory AuthMethodType = "SHA256_MEMORY"
-	AuthMethodMySQL41      AuthMethodType = "MYSQL41"
-)
 
 var defaultAuthMethods = []AuthMethodType{AuthMethodMySQL41, AuthMethodSHA256Memory}
 

--- a/xmysql/internal/statements/quote.go
+++ b/xmysql/internal/statements/quote.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package statements
+
+import (
+	"fmt"
+	"strings"
+)
+
+// QuoteValue quotes p so that it can be safely used to substituted placeholders
+// within a SQL query.
+func QuoteValue(p any) (string, error) {
+
+	switch v := p.(type) {
+	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		return fmt.Sprintf("%d", v), nil
+	case []byte:
+		return fmt.Sprintf("_binary'%x'", v), nil
+	case float32, float64:
+		return fmt.Sprintf("%f", v), nil
+	case string:
+		// handled as default (last return)
+	default:
+		return "", fmt.Errorf("cannot quote parameter with value type %T", p)
+	}
+
+	return "'" + p.(string) + "'", nil
+}
+
+func QuoteIdentifier(p string) (string, error) {
+	return "`" + strings.Replace(p, "`", "``", -1) + "`", nil
+}

--- a/xmysql/internal/statements/statements.go
+++ b/xmysql/internal/statements/statements.go
@@ -35,7 +35,7 @@ func SubstitutePlaceholders(stmt string, args ...any) (string, error) {
 			continue
 		}
 
-		quoted, err := QuoteSQLValue(arg)
+		quoted, err := QuoteValue(arg)
 		if err != nil {
 			return "", err
 		}
@@ -85,24 +85,4 @@ func PlaceholderIndexes(placeholder rune, query string) []int {
 	}
 
 	return indexes
-}
-
-// QuoteSQLValue quotes p so that it can be safely used to substituted placeholders
-// within a SQL query.
-func QuoteSQLValue(p any) (string, error) {
-
-	switch v := p.(type) {
-	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
-		return fmt.Sprintf("%d", v), nil
-	case []byte:
-		return fmt.Sprintf("_binary'%x'", v), nil
-	case float32, float64:
-		return fmt.Sprintf("%f", v), nil
-	case string:
-		// handled as default (last return)
-	default:
-		return "", fmt.Errorf("cannot quote parameter with value type %T", p)
-	}
-
-	return "'" + p.(string) + "'", nil
 }

--- a/xmysql/result_test.go
+++ b/xmysql/result_test.go
@@ -25,7 +25,7 @@ func TestResult_FetchRow(t *testing.T) {
 
 	ses, err := xmysql.CreateSession(context.Background(), config)
 	xt.OK(t, err)
-	xt.OK(t, ses.SetCurrentSchema(context.Background(), testSchema))
+	xt.OK(t, ses.SetActiveSchema(context.Background(), testSchema))
 
 	createTable := fmt.Sprintf(
 		"CREATE TABLE `%s` (id INT AUTO_INCREMENT PRIMARY KEY, c1 VARCHAR(30) NOT NULL)", tbl)
@@ -46,7 +46,7 @@ func TestResult_FetchRow(t *testing.T) {
 	t.Run("fetch", func(t *testing.T) {
 		ses, err := xmysql.CreateSession(context.Background(), config)
 		xt.OK(t, err)
-		xt.OK(t, ses.SetCurrentSchema(context.Background(), testSchema))
+		xt.OK(t, ses.SetActiveSchema(context.Background(), testSchema))
 
 		mUse := xxt.NewMemoryUse()
 		res, err := ses.ExecuteStatement(context.Background(),

--- a/xmysql/schema.go
+++ b/xmysql/schema.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package xmysql
+
+import (
+	"fmt"
+)
+
+// Schema defines the representation of a database schema. It provides
+// functionality to access the schema's contents.
+type Schema struct {
+	session *Session
+	name    string
+}
+
+// newSchema instantiates a new Schema object using session. If name is the
+// empty string, the current schema of session will be used.
+func newSchema(session *Session, name string) (*Schema, error) {
+	if session == nil {
+		return nil, fmt.Errorf("session closed")
+	}
+
+	return &Schema{
+		session: session,
+		name:    name,
+	}, nil
+}
+
+func (s *Schema) String() string {
+	return fmt.Sprintf("<Schema:%s:%s>", s.name, s.session)
+}
+
+// Name returns the schema or database name.
+func (s *Schema) Name() string {
+	return s.name
+}

--- a/xmysql/schema_test.go
+++ b/xmysql/schema_test.go
@@ -1,0 +1,3 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package xmysql_test


### PR DESCRIPTION
We add the possibility to use Session to retrieve a database object as `Schema`. The `Session.Schemas` can be used to retrieve all available schema's in the connected MySQL instance.

It is also possible to create drop schemas (databases) using the `Session` methods `CreateSchema` and `DropSchema`.

BREAKING CHANGE:
Users using `CurrentSchemaName` must now use Session method `ActiveSchemaName` and to use get the one configured `DefaultSchemaName`.

Resolves #61