### PR TITLE
feat(xmysql): manage collections using Schema object

### DIFF
--- a/.idea/watcherTasks.xml
+++ b/.idea/watcherTasks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ProjectTasksOptions">
-    <TaskOptions isEnabled="true">
+    <TaskOptions isEnabled="false">
       <option name="arguments" value="-w $FilePath$" />
       <option name="checkSyntaxErrors" value="true" />
       <option name="description" />

--- a/_support/pxmysql-compose/docker-compose.yml
+++ b/_support/pxmysql-compose/docker-compose.yml
@@ -24,7 +24,7 @@ services:
 
   go:
     container_name: pxmysql.test.go
-    image: golang:1.19-bullseye
+    image: golang:1.21-bullseye
     tty: true
     stdin_open: true
     volumes:

--- a/_support/pxmysql-compose/shared/goapps/unix_socket/go.mod
+++ b/_support/pxmysql-compose/shared/goapps/unix_socket/go.mod
@@ -1,6 +1,6 @@
 module example.com/unix_socket
 
-go 1.19
+go 1.21
 
 replace github.com/golistic/pxmysql => /go/src/github.com/golistic/pxmysql
 

--- a/_support/pxmysql-compose/shared/goapps/unix_socket/go.sum
+++ b/_support/pxmysql-compose/shared/goapps/unix_socket/go.sum
@@ -3,6 +3,7 @@ github.com/golistic/xgo v1.0.0 h1:NtwCDhGBJR0vOvn0l8S8z9wzmN3hYRM8Wwwd1+2BFO0=
 github.com/golistic/xgo v1.0.0/go.mod h1:em3spZJ1b8mrGv1P5Fx2Ewclaf0rqIfSwrzYIVnL6o4=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63 h1:m64FZMko/V45gv0bNmrNYoDEq8U5YUhetc9cBWKS1TQ=
 golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63/go.mod h1:0v4NqG35kSWCMzLaMeX+IQrlSnVE/bqGSyC2cz/9Le8=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.21
 toolchain go1.21.0
 
 require (
-	github.com/golistic/envs v1.0.1
 	github.com/golistic/gomake v0.9.4
 	github.com/golistic/xgo v1.0.0
 	golang.org/x/exp v0.0.0-20230817173708-d852ddb80c63

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golistic/envs v1.0.1 h1:IBK2/Vc4I/WpFcqiPGwC9kYrmZOj0b1HPs7NS+IyWn4=
-github.com/golistic/envs v1.0.1/go.mod h1:IOkqiFl8WD7xV/tcB1k2H7AiVyhdJG8BhWqA2vzUzrc=
 github.com/golistic/gomake v0.9.4 h1:6cOBeAsbSnacsskMvyg49DjCRCE9WnyhJv4Viy9rF9M=
 github.com/golistic/gomake v0.9.4/go.mod h1:IiYQuN6aK4Jb3QLA/rfOpeOqG7s8DNfBzVXZt8Pf6PA=
 github.com/golistic/shieldbadger v0.0.0-20230223210348-5649a4ba6aa9 h1:NBSzSvgVJjhI37ytLLcHLkRA7UTR/P1L/0dm6EY4GoE=

--- a/xmysql/_testdata/schema_collections.sql
+++ b/xmysql/_testdata/schema_collections.sql
@@ -1,0 +1,30 @@
+USE pxmysql_tests;
+
+DROP TABLE IF EXISTS not_collection_28380dew22;
+DROP TABLE IF EXISTS collection_wic28skwixkd;
+DROP TABLE IF EXISTS collection_weux73293jsnsj;
+
+CREATE TABLE not_collection_28380dew22
+(
+    id INT
+);
+
+CREATE TABLE collection_wic28skwixkd
+(
+    doc          json null,
+    _id          varbinary(32) as (json_unquote(json_extract(`doc`, _utf8mb4'$._id'))) stored
+        primary key,
+    _json_schema json as (_utf8mb4'{"type":"object"}'),
+    constraint $val_strict_wic28skwixkd
+        check (json_schema_valid(`_json_schema`, `doc`))
+);
+
+CREATE TABLE collection_weux73293jsnsj
+(
+    doc          json null,
+    _id          varbinary(32) as (json_unquote(json_extract(`doc`, _utf8mb4'$._id'))) stored
+        primary key,
+    _json_schema json as (_utf8mb4'{"type":"object"}'),
+    constraint $val_strict_weux73293jsnsj
+        check (json_schema_valid(`_json_schema`, `doc`))
+);

--- a/xmysql/collection.go
+++ b/xmysql/collection.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package xmysql
+
+import (
+	"context"
+	"fmt"
+	"slices"
+)
+
+type Collection struct {
+	schema  *Schema
+	session *Session
+	name    string
+}
+
+// newCollection instantiates a new Collection object with schema.
+func newCollection(schema *Schema, name string) (*Collection, error) {
+	if schema == nil || schema.session == nil {
+		return nil, fmt.Errorf("session closed")
+	}
+
+	if name == "" {
+		return nil, fmt.Errorf("invalid name")
+	}
+
+	return &Collection{
+		schema:  schema,
+		session: schema.session,
+		name:    name,
+	}, nil
+}
+
+func (c *Collection) String() string {
+	return fmt.Sprintf("<GetCollection:%s:%s>", c.name, c.schema)
+}
+
+// Name returns the collection.
+func (c *Collection) Name() string {
+	return c.name
+}
+
+func (c *Collection) CheckExistence(ctx context.Context) error {
+	names, err := c.schema.objectNames(ctx, ObjectCollection)
+	if err != nil {
+		return err
+	}
+
+	if _, ok := slices.BinarySearch(names, c.name); !ok {
+		return ErrNotAvailable
+	}
+
+	return nil
+}

--- a/xmysql/collection/create.go
+++ b/xmysql/collection/create.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package collection
+
+type CreateOptions struct {
+	ReuseExisting bool
+}
+
+type CreateOption func(opts *CreateOptions)
+
+func NewCreateOptions(opts ...CreateOption) *CreateOptions {
+	options := &CreateOptions{}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	return options
+}
+
+func CreateReuseExisting() CreateOption {
+	return func(opts *CreateOptions) {
+		opts.ReuseExisting = true
+	}
+}

--- a/xmysql/collection/get.go
+++ b/xmysql/collection/get.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package collection
+
+type GetOptions struct {
+	ValidateExistence bool
+}
+
+type GetOption func(opts *GetOptions)
+
+func NewGetOptions(opts ...GetOption) *GetOptions {
+	options := &GetOptions{}
+
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	return options
+}
+
+func GetValidateExistence() GetOption {
+	return func(opts *GetOptions) {
+		opts.ValidateExistence = true
+	}
+}

--- a/xmysql/errors.go
+++ b/xmysql/errors.go
@@ -1,0 +1,7 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package xmysql
+
+import "fmt"
+
+var ErrNotAvailable = fmt.Errorf("not available")

--- a/xmysql/internal/network/proto.go
+++ b/xmysql/internal/network/proto.go
@@ -7,6 +7,8 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+const NamespaceMySQLx = "mysqlx"
+
 // UnmarshalPartial parses the wire-format message in b and places the result in m.
 // The provided message must be mutable (e.g., a non-nil pointer to a message).
 // This is the same function as proto.Unmarshall except that AllowPartial option set to true.

--- a/xmysql/internal/statements/quote.go
+++ b/xmysql/internal/statements/quote.go
@@ -19,12 +19,10 @@ func QuoteValue(p any) (string, error) {
 	case float32, float64:
 		return fmt.Sprintf("%f", v), nil
 	case string:
-		// handled as default (last return)
+		return "'" + strings.ReplaceAll(v, "'", `\'`) + "'", nil
 	default:
 		return "", fmt.Errorf("cannot quote parameter with value type %T", p)
 	}
-
-	return "'" + p.(string) + "'", nil
 }
 
 func QuoteIdentifier(p string) (string, error) {

--- a/xmysql/internal/statements/quote_test.go
+++ b/xmysql/internal/statements/quote_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package statements_test
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/golistic/xgo/xt"
+
+	"github.com/golistic/pxmysql/xmysql/internal/statements"
+)
+
+func TestQuoteValue(t *testing.T) {
+	t.Run("strings", func(t *testing.T) {
+		var cases = []struct {
+			got string
+			exp string
+		}{
+			{
+				got: "Gopher",
+				exp: "'Gopher'",
+			},
+			{
+				got: "'Gopher'",
+				exp: `'\'Gopher\''`,
+			},
+			{
+				got: "'poop'; DROP TABLE gophers",
+				exp: `'\'poop\'; DROP TABLE gophers'`,
+			},
+			{
+				got: "🐰",
+				exp: `'🐰'`,
+			},
+		}
+
+		for i, c := range cases {
+			t.Run(strconv.Itoa(i+1), func(t *testing.T) {
+				got, err := statements.QuoteValue(c.got)
+				xt.OK(t, err)
+				xt.Eq(t, c.exp, got)
+			})
+		}
+	})
+}

--- a/xmysql/prepared.go
+++ b/xmysql/prepared.go
@@ -12,7 +12,7 @@ import (
 	"github.com/golistic/pxmysql/decimal"
 	"github.com/golistic/pxmysql/internal/mysqlx/mysqlxdatatypes"
 	"github.com/golistic/pxmysql/internal/mysqlx/mysqlxprepare"
-	"github.com/golistic/pxmysql/xmysql/internal/scalars"
+	"github.com/golistic/pxmysql/xmysql/xproto"
 )
 
 type Prepared struct {
@@ -43,79 +43,79 @@ func (p *Prepared) Execute(ctx context.Context, args ...any) (*Result, error) {
 		// ridiculous type-switch; preventing using reflection
 		switch v := a.(type) {
 		case nil:
-			pArgs[i] = scalars.Nil()
+			pArgs[i] = xproto.Nil()
 		case bool:
-			pArgs[i] = scalars.Bool(v)
+			pArgs[i] = xproto.Bool(v)
 		case *bool:
-			pArgs[i] = scalars.Bool(*v)
+			pArgs[i] = xproto.Bool(*v)
 		case int:
-			pArgs[i] = scalars.SignedInt(v)
+			pArgs[i] = xproto.SignedInt(v)
 		case int8:
-			pArgs[i] = scalars.SignedInt(v)
+			pArgs[i] = xproto.SignedInt(v)
 		case int16:
-			pArgs[i] = scalars.SignedInt(v)
+			pArgs[i] = xproto.SignedInt(v)
 		case int32:
-			pArgs[i] = scalars.SignedInt(v)
+			pArgs[i] = xproto.SignedInt(v)
 		case int64:
-			pArgs[i] = scalars.SignedInt(v)
+			pArgs[i] = xproto.SignedInt(v)
 		case uint:
-			pArgs[i] = scalars.UnsignedInt(v)
+			pArgs[i] = xproto.UnsignedInt(v)
 		case uint8:
-			pArgs[i] = scalars.UnsignedInt(v)
+			pArgs[i] = xproto.UnsignedInt(v)
 		case uint16:
-			pArgs[i] = scalars.UnsignedInt(v)
+			pArgs[i] = xproto.UnsignedInt(v)
 		case uint32:
-			pArgs[i] = scalars.UnsignedInt(v)
+			pArgs[i] = xproto.UnsignedInt(v)
 		case uint64:
-			pArgs[i] = scalars.UnsignedInt(v)
+			pArgs[i] = xproto.UnsignedInt(v)
 		case *int:
-			pArgs[i] = scalars.SignedInt(*v)
+			pArgs[i] = xproto.SignedInt(*v)
 		case *int8:
-			pArgs[i] = scalars.SignedInt(*v)
+			pArgs[i] = xproto.SignedInt(*v)
 		case *int16:
-			pArgs[i] = scalars.SignedInt(*v)
+			pArgs[i] = xproto.SignedInt(*v)
 		case *int32:
-			pArgs[i] = scalars.SignedInt(*v)
+			pArgs[i] = xproto.SignedInt(*v)
 		case *int64:
-			pArgs[i] = scalars.SignedInt(*v)
+			pArgs[i] = xproto.SignedInt(*v)
 		case *uint:
-			pArgs[i] = scalars.UnsignedInt(*v)
+			pArgs[i] = xproto.UnsignedInt(*v)
 		case *uint8:
-			pArgs[i] = scalars.UnsignedInt(*v)
+			pArgs[i] = xproto.UnsignedInt(*v)
 		case *uint16:
-			pArgs[i] = scalars.UnsignedInt(*v)
+			pArgs[i] = xproto.UnsignedInt(*v)
 		case *uint32:
-			pArgs[i] = scalars.UnsignedInt(*v)
+			pArgs[i] = xproto.UnsignedInt(*v)
 		case *uint64:
-			pArgs[i] = scalars.UnsignedInt(*v)
+			pArgs[i] = xproto.UnsignedInt(*v)
 		case string:
-			pArgs[i] = scalars.String(v)
+			pArgs[i] = xproto.String(v)
 		case *string:
-			pArgs[i] = scalars.String(v)
+			pArgs[i] = xproto.String(v)
 		case []byte:
-			pArgs[i] = scalars.Bytes(v)
+			pArgs[i] = xproto.Bytes(v)
 		case float32:
-			pArgs[i] = scalars.Float32(v)
+			pArgs[i] = xproto.Float32(v)
 		case *float32:
-			pArgs[i] = scalars.Float32(*v)
+			pArgs[i] = xproto.Float32(*v)
 		case float64:
-			pArgs[i] = scalars.Float64(v)
+			pArgs[i] = xproto.Float64(v)
 		case *float64:
-			pArgs[i] = scalars.Float64(*v)
+			pArgs[i] = xproto.Float64(*v)
 		case decimal.Decimal:
-			pArgs[i] = scalars.Decimal(v)
+			pArgs[i] = xproto.Decimal(v)
 		case *decimal.Decimal:
-			pArgs[i] = scalars.Decimal(*v)
+			pArgs[i] = xproto.Decimal(*v)
 		case time.Time:
-			if pArgs[i], err = scalars.Time(v, p.session.TimeLocation().String()); err != nil {
+			if pArgs[i], err = xproto.Time(v, p.session.TimeLocation().String()); err != nil {
 				return nil, err
 			}
 		case *time.Time:
-			if pArgs[i], err = scalars.Time(*v, p.session.TimeLocation().String()); err != nil {
+			if pArgs[i], err = xproto.Time(*v, p.session.TimeLocation().String()); err != nil {
 				return nil, err
 			}
 		case []string:
-			pArgs[i] = scalars.String(strings.Join(v, ","))
+			pArgs[i] = xproto.String(strings.Join(v, ","))
 		default:
 			return nil, fmt.Errorf("argument type '%T' not supported", a)
 		}

--- a/xmysql/schema.go
+++ b/xmysql/schema.go
@@ -3,7 +3,19 @@
 package xmysql
 
 import (
+	"context"
 	"fmt"
+	"sort"
+
+	"github.com/golistic/pxmysql/null"
+	"github.com/golistic/pxmysql/xmysql/collection"
+	"github.com/golistic/pxmysql/xmysql/xproto"
+)
+
+type ObjectKind string
+
+const (
+	ObjectCollection ObjectKind = "COLLECTION"
 )
 
 // Schema defines the representation of a database schema. It provides
@@ -33,4 +45,138 @@ func (s *Schema) String() string {
 // Name returns the schema or database name.
 func (s *Schema) Name() string {
 	return s.name
+}
+
+// GetCollection retrieve the collection using its name.
+// To keep compatible with behavior seen it MySQL connectors, when the collection
+// does not exist, by default, no error is returned. To return ErrNotAvailable instead,
+// use the functional option collection.GetValidateExistence.
+func (s *Schema) GetCollection(ctx context.Context, name string, options ...collection.GetOption) (*Collection, error) {
+
+	c, err := newCollection(s, name)
+	if err != nil {
+		return nil, fmt.Errorf("getting collection (%w)", err)
+	}
+
+	opts := collection.NewGetOptions(options...)
+	if opts.ValidateExistence {
+		if err := c.CheckExistence(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	return c, nil
+}
+
+// GetCollections retrieve all available collections (does not include views or tables).
+func (s *Schema) GetCollections(ctx context.Context) ([]*Collection, error) {
+
+	names, err := s.objectNames(ctx, ObjectCollection)
+	if err != nil {
+		return nil, fmt.Errorf("getting collections (%w)", err)
+	}
+
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	collections := make([]*Collection, len(names))
+	for i, name := range names {
+		collections[i], err = newCollection(s, name)
+		if err != nil {
+			return nil, fmt.Errorf("getting collections (%w)", err)
+		}
+	}
+
+	return collections, nil
+}
+
+// CreateCollection creates a new collection. If the functional option
+// collection.CreateReuseExisting is used, no error is reported when collection
+// already exists.
+func (s *Schema) CreateCollection(ctx context.Context, name string,
+	options ...collection.CreateOption) (*Collection, error) {
+
+	c, err := newCollection(s, name)
+	if err != nil {
+		return nil, fmt.Errorf("creating collection (%w)", err)
+	}
+
+	opts := collection.NewCreateOptions(options...)
+
+	args := xproto.CommandArgs(
+		xproto.ObjectField("schema", s.name),
+		xproto.ObjectField("name", name),
+		xproto.ObjectField("options", xproto.ObjectFields{
+			xproto.ObjectField("reuse_existing", opts.ReuseExisting),
+		}),
+	)
+
+	_, err = s.session.ExecCommand(ctx, "create_collection", args)
+	if err != nil {
+		return nil, fmt.Errorf("creating collection (%w)", err)
+	}
+
+	return c, nil
+}
+
+// DropCollection drops the collection.
+func (s *Schema) DropCollection(ctx context.Context, name string) error {
+
+	args := xproto.CommandArgs(
+		xproto.ObjectField("schema", s.name),
+		xproto.ObjectField("name", name),
+	)
+
+	_, err := s.session.ExecCommand(ctx, "drop_collection", args)
+	if err != nil {
+		return fmt.Errorf("dropping collection (%w)", err)
+	}
+
+	return nil
+}
+
+func (s *Schema) objectNames(ctx context.Context, kind ObjectKind) ([]string, error) {
+
+	args := xproto.CommandArgs(
+		xproto.ObjectField("schema", s.name),
+	)
+
+	if err := s.session.Write(ctx, xproto.Command("list_objects", args)); err != nil {
+		return nil, err
+	}
+
+	res, err := s.session.handleResult(ctx, func(r *Result) bool {
+		return r.stmtOK
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(res.Rows) == 0 {
+		return nil, nil
+	}
+
+	var names []string
+	for _, row := range res.Rows {
+		objType, ok := row.Values[1].(string)
+		if !ok || objType != string(kind) {
+			continue
+		}
+
+		name, ok := row.Values[0].(null.String)
+		if !ok || !name.Valid {
+			continue
+		}
+
+		names = append(names, name.String)
+	}
+
+	if len(names) == 0 {
+		return nil, nil
+	}
+
+	sort.Strings(names)
+
+	return names, nil
 }

--- a/xmysql/schema_test.go
+++ b/xmysql/schema_test.go
@@ -1,3 +1,117 @@
 // Copyright (c) 2023, Geert JM Vanderkelen
 
 package xmysql_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/golistic/xgo/xt"
+
+	"github.com/golistic/pxmysql/internal/xxt"
+	"github.com/golistic/pxmysql/xmysql"
+	"github.com/golistic/pxmysql/xmysql/collection"
+)
+
+func TestSchema_Collections(t *testing.T) {
+
+	config := &xmysql.ConnectConfig{
+		Address:  testContext.XPluginAddr,
+		Username: xxt.UserNative,
+	}
+	config.SetPassword(xxt.UserNativePwd)
+
+	t.Run("all collections", func(t *testing.T) {
+
+		xt.OK(t, testContext.Server.LoadSQLScript("schema_collections"))
+
+		ses, err := xmysql.CreateSession(context.Background(), config)
+		xt.OK(t, err)
+
+		exp := []string{"collection_wic28skwixkd", "collection_weux73293jsnsj"}
+		sort.Strings(exp)
+
+		schema, err := ses.SchemaWithName(context.Background(), "pxmysql_tests")
+		xt.OK(t, err)
+
+		collections, err := schema.GetCollections(context.Background())
+		xt.OK(t, err)
+
+		xt.Assert(t, len(collections) >= len(exp), fmt.Sprintf("expected at least %d", len(exp)))
+
+		var got []string
+		for _, s := range collections {
+			got = append(got, s.Name())
+		}
+		sort.Strings(got)
+
+		xt.Eq(t, exp, got)
+	})
+}
+
+func TestSchema_CreateCollection(t *testing.T) {
+
+	config := &xmysql.ConnectConfig{
+		Address:  testContext.XPluginAddr,
+		Username: xxt.UserNative,
+		Schema:   "pxmysql_tests",
+	}
+	config.SetPassword(xxt.UserNativePwd)
+
+	ses, err := xmysql.CreateSession(context.Background(), config)
+	xt.OK(t, err)
+
+	schema, err := ses.Schema(context.Background())
+	xt.OK(t, err)
+
+	t.Run("name is required", func(t *testing.T) {
+
+		ctx := context.Background()
+		_, err := schema.CreateCollection(ctx, "")
+		xt.KO(t, err)
+		xt.Eq(t, "creating collection (invalid name)", err.Error())
+	})
+
+	t.Run("create and drop", func(t *testing.T) {
+
+		ctx := context.Background()
+		name := "ciwejkuwmidi2938x"
+		c, err := schema.CreateCollection(ctx, name)
+		xt.OK(t, err)
+		xt.Eq(t, name, c.Name())
+
+		t.Run("check existence", func(t *testing.T) {
+			c, err := schema.GetCollection(ctx, name, collection.GetValidateExistence())
+			xt.OK(t, err)
+			xt.Eq(t, name, c.Name())
+
+			t.Run("drop", func(t *testing.T) {
+				err := schema.DropCollection(ctx, name)
+				xt.OK(t, err)
+
+				err = c.CheckExistence(ctx)
+				xt.KO(t, err)
+				xt.Assert(t, errors.Is(err, xmysql.ErrNotAvailable))
+			})
+		})
+	})
+
+	t.Run("reuse existing", func(t *testing.T) {
+
+		ctx := context.Background()
+
+		name := "eovwo28373"
+		_, err := schema.CreateCollection(ctx, name)
+		xt.OK(t, err)
+
+		_, err = schema.CreateCollection(ctx, name)
+		xt.KO(t, err)
+		xt.Eq(t, "table 'eovwo28373' already exists [1050:42S01]", errors.Unwrap(err).Error())
+
+		_, err = schema.CreateCollection(ctx, name, collection.CreateReuseExisting())
+		xt.OK(t, err)
+	})
+}

--- a/xmysql/xproto/command.go
+++ b/xmysql/xproto/command.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package xproto
+
+import (
+	"github.com/golistic/xgo/xstrings"
+
+	"github.com/golistic/pxmysql/internal/mysqlx/mysqlxdatatypes"
+	"github.com/golistic/pxmysql/internal/mysqlx/mysqlxsql"
+	"github.com/golistic/pxmysql/xmysql/internal/network"
+)
+
+func Command(command string, args *mysqlxdatatypes.Any) *mysqlxsql.StmtExecute {
+	return &mysqlxsql.StmtExecute{
+		Namespace: xstrings.Pointer(network.NamespaceMySQLx),
+		Stmt:      []byte(command),
+		Args:      []*mysqlxdatatypes.Any{args},
+	}
+}
+
+func CommandArgs(fields ...*mysqlxdatatypes.Object_ObjectField) *mysqlxdatatypes.Any {
+	return &mysqlxdatatypes.Any{
+		Type: mysqlxdatatypes.Any_OBJECT.Enum(),
+		Obj: &mysqlxdatatypes.Object{
+			Fld: fields,
+		},
+	}
+}

--- a/xmysql/xproto/datatypes.go
+++ b/xmysql/xproto/datatypes.go
@@ -1,6 +1,6 @@
 // Copyright (c) 2023, Geert JM Vanderkelen
 
-package scalars
+package xproto
 
 import (
 	"fmt"

--- a/xmysql/xproto/fields.go
+++ b/xmysql/xproto/fields.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2023, Geert JM Vanderkelen
+
+package xproto
+
+import (
+	"github.com/golistic/xgo/xstrings"
+
+	"github.com/golistic/pxmysql/internal/mysqlx/mysqlxdatatypes"
+)
+
+type ObjectFields = []*mysqlxdatatypes.Object_ObjectField
+
+func ObjectField[T ~string | ~bool | ~[]*mysqlxdatatypes.Object_ObjectField](key string, value T) *mysqlxdatatypes.Object_ObjectField {
+	f := &mysqlxdatatypes.Object_ObjectField{
+		Key: xstrings.Pointer(key),
+	}
+
+	switch v := any(value).(type) {
+	case string:
+		f.Value = String(v)
+	case bool:
+		f.Value = Bool(v)
+	case []*mysqlxdatatypes.Object_ObjectField:
+		f.Value = &mysqlxdatatypes.Any{
+			Type: mysqlxdatatypes.Any_OBJECT.Enum(),
+			Obj: &mysqlxdatatypes.Object{
+				Fld: v,
+			},
+		}
+	default:
+		panic("unsupported value type")
+	}
+
+	return f
+}


### PR DESCRIPTION
We add the following Schema-methods:
* `CreateCollection`
* `DropCollection`
* `GetCollections` (to get list of all collections available)
* `GetCollection`

The names of the methods are inline with the MySQL X DevAPI

Resolves #56