### PR TITLE
enh(xmysql): CreateSession becomes GetSession and Schema method, GetS…

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,9 +2,13 @@
 <project version="4">
   <component name="CommitMessageInspectionProfile">
     <profile version="1.0">
-      <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true">
+        <option name="RIGHT_MARGIN" value="100" />
+      </inspection_tool>
       <inspection_tool class="SubjectBodySeparation" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true">
+        <option name="RIGHT_MARGIN" value="90" />
+      </inspection_tool>
     </profile>
   </component>
   <component name="VcsDirectoryMappings">

--- a/README.md
+++ b/README.md
@@ -70,6 +70,21 @@ authentication method `caching_sha2_password`.
 **Warning**: during the v0.9 pre-releases, the below is subject to change.
 
 ```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/golistic/xgo/xstrings"
+
+	"github.com/golistic/pxmysql/null"
+	"github.com/golistic/pxmysql/xmysql"
+)
+
+func main() {
 	config := &xmysql.ConnectConfig{
 		Address:  "127.0.0.1:53360", // default X Plugin port
 		Username: "user_native",
@@ -79,7 +94,7 @@ authentication method `caching_sha2_password`.
 
 	ctx := context.Background()
 
-	session, err := xmysql.CreateSession(ctx, config)
+	session, err := xmysql.GetSession(ctx, config)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -97,6 +112,7 @@ authentication method `caching_sha2_password`.
 
 		fmt.Printf("Table %s has %d rows and was created %s.\n", tableName.String, tableRows.Uint64, tableCreateTime)
 	}
+}
 ```
 
 Features

--- a/cmd/gencollations/main.go
+++ b/cmd/gencollations/main.go
@@ -39,7 +39,7 @@ func main() {
 		UseTLS:   true,
 	}
 
-	ses, err := xmysql.CreateSession(context.Background(), config)
+	ses, err := xmysql.GetSession(context.Background(), config)
 	if err != nil {
 		fmt.Printf("Error: %s\n", err)
 		os.Exit(1)

--- a/connector.go
+++ b/connector.go
@@ -33,7 +33,7 @@ func (c connector) Connect(ctx context.Context) (driver.Conn, error) {
 		config.Address = c.dataSource.Address
 	}
 
-	ses, err := xmysql.CreateSession(ctx, config)
+	ses, err := xmysql.GetSession(ctx, config)
 	if err != nil {
 		return nil, err
 	}

--- a/mysqlerrors/test_errors/mysqlerrors_test.go
+++ b/mysqlerrors/test_errors/mysqlerrors_test.go
@@ -22,7 +22,7 @@ func TestMySQLErrors(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
-		_, err := xmysql.CreateSession(ctx, config)
+		_, err := xmysql.GetSession(ctx, config)
 		xt.Eq(t, "unknown MySQL server host '127.0.0.40:33060' (i/o timeout) [2005:HY000]", err.Error())
 		xt.Eq(t, "i/o timeout", errors.Unwrap(err).Error())
 	})

--- a/xmysql/examples_test.go
+++ b/xmysql/examples_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/golistic/pxmysql/xmysql"
 )
 
-func ExampleConnection_NewSession_auto_notls() {
+func ExampleGetSession_auto_notls() {
 	config := &xmysql.ConnectConfig{
 		Address:  "127.0.0.1:53360", // see _support/pxmysql-compose/docker-compose.yml
 		Username: "user_native",
 	}
 	config.SetPassword("pwd_user_native")
 
-	session, err := xmysql.CreateSession(context.Background(), config)
+	session, err := xmysql.GetSession(context.Background(), config)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -26,7 +26,7 @@ func ExampleConnection_NewSession_auto_notls() {
 	// Output: TLS: false
 }
 
-func ExampleConnection_NewSession_plain_withtls() {
+func ExampleGetSession_plain_withtls() {
 	config := &xmysql.ConnectConfig{
 		Address:    "127.0.0.1:53360", // see _support/pxmysql-compose/docker-compose.yml
 		AuthMethod: xmysql.AuthMethodPlain,
@@ -35,7 +35,7 @@ func ExampleConnection_NewSession_plain_withtls() {
 	}
 	config.SetPassword("pwd_user_native")
 
-	session, err := xmysql.CreateSession(context.Background(), config)
+	session, err := xmysql.GetSession(context.Background(), config)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -56,7 +56,7 @@ func ExampleSession_ExecuteStatement() {
 	}
 	config.SetPassword("pwd_user_native")
 
-	session, err := xmysql.CreateSession(context.Background(), config)
+	session, err := xmysql.GetSession(context.Background(), config)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/xmysql/prepared_test.go
+++ b/xmysql/prepared_test.go
@@ -32,7 +32,7 @@ func TestPrepared_Execute(t *testing.T) {
 	}
 	config.SetPassword(xxt.UserNativePwd)
 
-	ses, err := xmysql.CreateSession(context.Background(), config)
+	ses, err := xmysql.GetSession(context.Background(), config)
 	xt.OK(t, err)
 
 	t.Run("all supported Go types", func(t *testing.T) {

--- a/xmysql/result_test.go
+++ b/xmysql/result_test.go
@@ -23,7 +23,7 @@ func TestResult_FetchRow(t *testing.T) {
 
 	tbl := "bulk_fidiEfiS223"
 
-	ses, err := xmysql.CreateSession(context.Background(), config)
+	ses, err := xmysql.GetSession(context.Background(), config)
 	xt.OK(t, err)
 	xt.OK(t, ses.SetActiveSchema(context.Background(), testSchema))
 
@@ -44,7 +44,7 @@ func TestResult_FetchRow(t *testing.T) {
 	}
 
 	t.Run("fetch", func(t *testing.T) {
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 		xt.OK(t, ses.SetActiveSchema(context.Background(), testSchema))
 

--- a/xmysql/schema_test.go
+++ b/xmysql/schema_test.go
@@ -28,13 +28,13 @@ func TestSchema_Collections(t *testing.T) {
 
 		xt.OK(t, testContext.Server.LoadSQLScript("schema_collections"))
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		exp := []string{"collection_wic28skwixkd", "collection_weux73293jsnsj"}
 		sort.Strings(exp)
 
-		schema, err := ses.SchemaWithName(context.Background(), "pxmysql_tests")
+		schema, err := ses.GetSchemaWithName(context.Background(), "pxmysql_tests")
 		xt.OK(t, err)
 
 		collections, err := schema.GetCollections(context.Background())
@@ -61,10 +61,10 @@ func TestSchema_CreateCollection(t *testing.T) {
 	}
 	config.SetPassword(xxt.UserNativePwd)
 
-	ses, err := xmysql.CreateSession(context.Background(), config)
+	ses, err := xmysql.GetSession(context.Background(), config)
 	xt.OK(t, err)
 
-	schema, err := ses.Schema(context.Background())
+	schema, err := ses.GetSchema(context.Background())
 	xt.OK(t, err)
 
 	t.Run("name is required", func(t *testing.T) {

--- a/xmysql/session.go
+++ b/xmysql/session.go
@@ -49,9 +49,9 @@ type Session struct {
 	timeLocation       *time.Location
 }
 
-// CreateSession instantiates a new session object connecting with given config and
+// GetSession instantiates a new session object connecting with given config and
 // opens the connection.
-func CreateSession(ctx context.Context, config *ConnectConfig) (*Session, error) {
+func GetSession(ctx context.Context, config *ConnectConfig) (*Session, error) {
 	ses, err := NewSession(config)
 	if err != nil {
 		return nil, err
@@ -410,13 +410,13 @@ func (ses *Session) DefaultSchemaName() string {
 	return ses.defaultSchemaName
 }
 
-// Schema returns a new Schema object allowing access to contents of the active schema of this session.
-func (ses *Session) Schema(_ context.Context) (*Schema, error) {
+// GetSchema returns a new Schema object allowing access to contents of the active schema of this session.
+func (ses *Session) GetSchema(_ context.Context) (*Schema, error) {
 	return newSchema(ses, ses.activeSchemaName)
 }
 
-// SchemaWithName returns a new Schema object allowing access to contents of the named schema using this session.
-func (ses *Session) SchemaWithName(_ context.Context, name string) (*Schema, error) {
+// GetSchemaWithName returns a new Schema object allowing access to contents of the named schema using this session.
+func (ses *Session) GetSchemaWithName(_ context.Context, name string) (*Schema, error) {
 	return newSchema(ses, name)
 }
 
@@ -467,7 +467,7 @@ func (ses *Session) CreateSchema(ctx context.Context, name string) (*Schema, err
 		return nil, fmt.Errorf("creating schema (%w)", err)
 	}
 
-	return ses.SchemaWithName(ctx, name)
+	return ses.GetSchemaWithName(ctx, name)
 }
 
 // DropSchema drops a schema or database with given name.
@@ -486,7 +486,7 @@ func (ses *Session) DropSchema(ctx context.Context, name string) error {
 }
 
 // Open opens the connection to the MySQL server. This method is called by
-// CreateSession, but not NewSession.
+// GetSession, but not NewSession.
 func (ses *Session) Open(ctx context.Context) error {
 	var err error
 

--- a/xmysql/session_test.go
+++ b/xmysql/session_test.go
@@ -153,7 +153,7 @@ func TestCreateSession(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 		defer cancel()
 
-		_, err := xmysql.CreateSession(ctx, expConfig)
+		_, err := xmysql.GetSession(ctx, expConfig)
 		xt.KO(t, errors.Unwrap(err))
 		xt.Eq(t, "i/o timeout", errors.Unwrap(err).Error())
 	})
@@ -165,7 +165,7 @@ func TestCreateSession(t *testing.T) {
 		}
 		config.SetPassword("pwd_user_native")
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		xt.Assert(t, ses.ServerCapabilities() != nil)
@@ -180,7 +180,7 @@ func TestCreateSession(t *testing.T) {
 			Address: testContext.MySQLAddr,
 		}
 
-		_, err := xmysql.CreateSession(context.Background(), config)
+		_, err := xmysql.GetSession(context.Background(), config)
 		xt.KO(t, err)
 		xt.Eq(t, "wrong protocol [2005:HY000]", err.Error())
 	})
@@ -206,7 +206,7 @@ func TestCreateSession(t *testing.T) {
 			Address: addr,
 		}
 
-		_, err = xmysql.CreateSession(context.Background(), config)
+		_, err = xmysql.GetSession(context.Background(), config)
 		xt.KO(t, err)
 		xt.Eq(t, "failed reading message payload (unexpected EOF)", err.Error())
 	})
@@ -219,7 +219,7 @@ func TestCreateSession(t *testing.T) {
 		}
 		config.SetPassword(xxt.UserNativePwd)
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		xt.Assert(t, ses.ServerCapabilities() != nil)
@@ -238,7 +238,7 @@ func TestCreateSession(t *testing.T) {
 		}
 		config.SetPassword(xxt.UserNativePwd)
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		xt.Assert(t, ses.ServerCapabilities() != nil)
@@ -261,7 +261,7 @@ func TestCreateSession(t *testing.T) {
 		}
 		config.SetPassword(xxt.UserNativePwd)
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		xt.Assert(t, ses.ServerCapabilities() != nil)
@@ -280,7 +280,7 @@ func TestCreateSession(t *testing.T) {
 		}
 		config.SetPassword(xxt.UserNativePwd)
 
-		_, err := xmysql.CreateSession(context.Background(), config)
+		_, err := xmysql.GetSession(context.Background(), config)
 		xt.KO(t, err)
 		xt.Assert(t, strings.Contains(err.Error(), "plain text authentication only supported over TLS"))
 	})
@@ -294,7 +294,7 @@ func TestCreateSession(t *testing.T) {
 		}
 		config.SetPassword(xxt.UserNativePwd)
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 		xt.Eq(t, xmysql.AuthMethodMySQL41, ses.AuthMethod())
 	})
@@ -308,7 +308,7 @@ func TestCreateSession(t *testing.T) {
 		}
 		config.SetPassword(xxt.UserNativePwd)
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 		xt.Eq(t, xmysql.AuthMethodMySQL41, ses.AuthMethod())
 		xt.Assert(t, ses.UsesTLS(), "expected tls.Conn")
@@ -324,7 +324,7 @@ func TestCreateSession(t *testing.T) {
 		}
 		config.SetPassword(xxt.UserNativePwd)
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 		xt.Eq(t, xmysql.AuthMethodPlain, ses.AuthMethod())
 		xt.Assert(t, ses.UsesTLS(), "expected tls.Conn")
@@ -340,7 +340,7 @@ func TestCreateSession(t *testing.T) {
 		}
 		config.SetPassword(xxt.UserCachedSHA256Pwd)
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 		defer func() { xt.OK(t, ses.Close()) }()
 
@@ -361,7 +361,7 @@ func TestCreateSession(t *testing.T) {
 			Username: username,
 		}).SetPassword(password)
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 		defer func() { xt.OK(t, ses.Close()) }()
 
@@ -374,7 +374,7 @@ func TestCreateSession(t *testing.T) {
 			}
 			config.SetPassword(password)
 
-			ses, err := xmysql.CreateSession(context.Background(), config)
+			ses, err := xmysql.GetSession(context.Background(), config)
 			xt.OK(t, err)
 			defer func() { xt.OK(t, ses.Close()) }()
 
@@ -389,7 +389,7 @@ func TestCreateSession(t *testing.T) {
 				}
 				config.SetPassword(password)
 
-				ses, err := xmysql.CreateSession(context.Background(), config)
+				ses, err := xmysql.GetSession(context.Background(), config)
 				xt.OK(t, err)
 				defer func() { xt.OK(t, ses.Close()) }()
 
@@ -412,7 +412,7 @@ func TestCreateSession(t *testing.T) {
 		}
 		config.SetPassword(xxt.UserNativePwd)
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		sesZone, err := ses.TimeZone(context.Background())
@@ -432,7 +432,7 @@ func TestSession_ExecuteStatement(t *testing.T) {
 	t.Run("numeric data types", func(t *testing.T) {
 		xt.OK(t, testContext.Server.LoadSQLScript("base", "data_types_numeric"))
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		xt.OK(t, ses.SetActiveSchema(context.Background(), testSchema))
@@ -530,7 +530,7 @@ func TestSession_ExecuteStatement(t *testing.T) {
 	t.Run("datetime data types", func(t *testing.T) {
 		xt.OK(t, testContext.Server.LoadSQLScript("base", "data_types_datetime"))
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		xt.OK(t, ses.SetActiveSchema(context.Background(), testSchema))
@@ -594,7 +594,7 @@ func TestSession_ExecuteStatement(t *testing.T) {
 	t.Run("string data types", func(t *testing.T) {
 		xt.OK(t, testContext.Server.LoadSQLScript("base", "data_types_string"))
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		xt.OK(t, ses.SetActiveSchema(context.Background(), testSchema))
@@ -644,7 +644,7 @@ func TestSession_ExecuteStatement(t *testing.T) {
 	t.Run("execute INSERT", func(t *testing.T) {
 		xt.OK(t, testContext.Server.LoadSQLScript("base", "inserting.sql"))
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		xt.OK(t, ses.SetActiveSchema(context.Background(), testSchema))
@@ -665,7 +665,7 @@ func TestSession_ExecuteStatement(t *testing.T) {
 	})
 
 	t.Run("use arguments and placeholders", func(t *testing.T) {
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		res, err := ses.ExecuteStatement(context.Background(), "SELECT ?, ?, '?', ? from dual", 1, "one", 3)
@@ -679,7 +679,7 @@ func TestSession_ExecuteStatement(t *testing.T) {
 	})
 
 	t.Run("zero hour timestamp", func(t *testing.T) {
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		res, err := ses.ExecuteStatement(context.Background(),
@@ -701,7 +701,7 @@ func TestSession_CurrentSchema(t *testing.T) {
 		}
 		config.SetPassword(xxt.UserNativePwd)
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		schema := ses.ActiveSchemaName()
@@ -716,7 +716,7 @@ func TestSession_CurrentSchema(t *testing.T) {
 		}
 		config.SetPassword(xxt.UserNativePwd)
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		schema := ses.ActiveSchemaName()
@@ -737,7 +737,7 @@ func TestSession_SetTimeZone(t *testing.T) {
 	xt.OK(t, err)
 
 	t.Run("default UTC when no time zone is set", func(t *testing.T) {
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		// without time location set, timestamps returned by MySQL are UTC
@@ -753,7 +753,7 @@ func TestSession_SetTimeZone(t *testing.T) {
 	})
 
 	t.Run("set time zone for session", func(t *testing.T) {
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		// set time location for session
@@ -781,7 +781,7 @@ func TestSession_SetCollation(t *testing.T) {
 	config.SetPassword(xxt.UserNativePwd)
 
 	t.Run("set collation and retrieve", func(t *testing.T) {
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		exp := xmysql.Collations["utf8mb4_sinhala_ci"]
@@ -793,7 +793,7 @@ func TestSession_SetCollation(t *testing.T) {
 	})
 
 	t.Run("set invalid collation", func(t *testing.T) {
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		c := "big5_chinese_ci"
@@ -810,7 +810,7 @@ func TestSession_PrepareStatement(t *testing.T) {
 	}
 	config.SetPassword(xxt.UserNativePwd)
 
-	ses, err := xmysql.CreateSession(context.Background(), config)
+	ses, err := xmysql.GetSession(context.Background(), config)
 	xt.OK(t, err)
 
 	stmt := "SELECT SQRT(POW(?,2) + POW(?,2)) AS hypotenuse"
@@ -831,7 +831,7 @@ func TestSession_DeallocatePrepareStatement(t *testing.T) {
 	}
 	config.SetPassword(xxt.UserNativePwd)
 
-	ses, err := xmysql.CreateSession(context.Background(), config)
+	ses, err := xmysql.GetSession(context.Background(), config)
 	xt.OK(t, err)
 
 	t.Run("successfully deallocate", func(t *testing.T) {
@@ -858,14 +858,14 @@ func TestSession_ActiveSchemaName(t *testing.T) {
 	config.SetPassword(xxt.UserNativePwd)
 
 	t.Run("current database name as configured", func(t *testing.T) {
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		xt.Eq(t, config.Schema, ses.ActiveSchemaName())
 	})
 
 	t.Run("change active schema", func(t *testing.T) {
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		exp := "pxmysql_tests_a"
@@ -883,7 +883,7 @@ func TestSession_Schemas(t *testing.T) {
 	config.SetPassword(xxt.UserNativePwd)
 
 	t.Run("all databases", func(t *testing.T) {
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		exp := []string{"information_schema", "performance_schema", "pxmysql_tests", "pxmysql_tests_a"}
@@ -914,7 +914,7 @@ func TestSession_CreateSchema(t *testing.T) {
 			Password: xstrings.Pointer(testContext.MySQLRootPwd),
 		}
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		schemaName := "pxmysql_2839cks829dka"
@@ -935,7 +935,7 @@ func TestSession_CreateSchema(t *testing.T) {
 		}
 		config.SetPassword(xxt.UserNativePwd)
 
-		ses, err := xmysql.CreateSession(context.Background(), config)
+		ses, err := xmysql.GetSession(context.Background(), config)
 		xt.OK(t, err)
 
 		schemaName := "pxmysql_sico29d9kpap21"


### PR DESCRIPTION
…chema

BREAKING CHANGE:
To align with the MySQL X DevAPI, we rename `xmysql.CreateSession` as `xmysql.GetSession`, not keeping the old name. The methods `Session.Schema` and `Session.SchemaWithName` have been renamed as `Session.GetSchema` and `Session.GetSchemaWithName`, again, not keeping the old names.

Resolves #64